### PR TITLE
Fix deprecation warnings

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set Node.js 10.x
       uses: actions/setup-node@master
       with:
-        version: 10.x
+        node-version: 10
 
     - name: npm install
       run: npm install

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Geert van der Cruijsen",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.0.0",
+    "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.0",
     "@actions/io": "^1.0.0",
     "@actions/tool-cache": "^1.0.0",


### PR DESCRIPTION
- Updates to `1.2.6` to fix addPath deprecation
- Replaces deprecated node-setup property from `version` to `node-version`